### PR TITLE
Check that orders are from eligible shoppers and print a message on the cover sheet if not.

### DIFF
--- a/PrintOrders.ipynb
+++ b/PrintOrders.ipynb
@@ -387,16 +387,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "6adeb249-a2a8-4d5c-b05e-8c884589cfec",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# allorders.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "id": "95ef6519-c4e0-45db-b04b-b6581988db57",
    "metadata": {},
    "outputs": [],
@@ -427,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "bd847c7d-13e8-4576-b721-a2eec3bb98f0",
    "metadata": {},
    "outputs": [],
@@ -514,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "291fee9b-8b63-4ec4-9372-1785b59989b7",
    "metadata": {},
    "outputs": [],
@@ -540,7 +530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "d923049b-0705-490f-bb98-81d6a5f1aa32",
    "metadata": {},
    "outputs": [],
@@ -566,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "260f18f3-1c02-4f63-afb1-f003c08837ff",
    "metadata": {},
    "outputs": [],
@@ -590,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "57b077d3-83e2-4a02-bd98-a39af7e0410e",
    "metadata": {},
    "outputs": [],
@@ -630,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "f12c546a-a6dd-41e3-bf69-1352c03f66e4",
    "metadata": {},
    "outputs": [],
@@ -697,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "954c262b-a785-4dea-aca5-de04a2a09732",
    "metadata": {},
    "outputs": [],
@@ -725,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "d91f6e5a-941c-4156-a2d1-6a8919c15cce",
    "metadata": {},
    "outputs": [],
@@ -737,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "27b866db-c012-4186-b8ab-c2e722c26ac3",
    "metadata": {},
    "outputs": [],
@@ -776,7 +766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "6a4a3751-7631-4447-82f9-34f39f7d3ce7",
    "metadata": {},
    "outputs": [

--- a/PrintOrders.ipynb
+++ b/PrintOrders.ipynb
@@ -137,8 +137,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "42 orders in input.\n",
-      "42 orders filtered by date and time.\n"
+      "28 orders in input.\n",
+      "28 orders filtered by date and time.\n"
      ]
     }
    ],
@@ -304,8 +304,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "48 shoppers to check in.\n",
-      "43 shoppers checked in.\n"
+      "34 shoppers to check in.\n",
+      "Shopper  46702384  is not eligible to check in.\n",
+      "32 shoppers checked in.\n"
      ]
     }
    ],
@@ -319,8 +320,16 @@
     "events = breeze_api.list_events(start=title_date, end=title_date)\n",
     "shoppingevent = [e for e in events if e['name'] == 'Food Pantry'][0]\n",
     "\n",
+    "eligible_ids = [e['id'] for e in breeze_api.list_eligible_people(instance_id=shoppingevent['id'])]\n",
+    "ineligible_shoppers = []\n",
+    "\n",
     "for id in shopper_ids:\n",
-    "    check = breeze_api.event_check_in(person_id=id, instance_id=shoppingevent['id'])\n",
+    "    if id in eligible_ids:\n",
+    "        check = breeze_api.event_check_in(person_id=id, instance_id=shoppingevent['id'])\n",
+    "    else:\n",
+    "        print('Shopper ', id, ' is not eligible to check in.')\n",
+    "        person = breeze_api.get_person_details(person_id = id)\n",
+    "        ineligible_shoppers.append('{fname} {lname} ({id})'.format(id = id, fname = person['first_name'], lname = person['last_name']))\n",
     "\n",
     "attendance = len(breeze_api.list_attendance(instance_id=shoppingevent['id']))\n",
     "print('{count} shoppers checked in.'.format(count = attendance))"
@@ -336,8 +345,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "37 orders deduped.\n",
-      "Duplicate orders received from {'jen bawden', 'Patricia Alielouahed', 'Arnold Bonner', 'Judith E Plum', 'Michael Onufrak'}\n"
+      "27 orders deduped.\n",
+      "Duplicate orders received from {'Jennifer Thibeau'}\n"
      ]
     }
    ],
@@ -378,6 +387,16 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "6adeb249-a2a8-4d5c-b05e-8c884589cfec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# allorders.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "95ef6519-c4e0-45db-b04b-b6581988db57",
    "metadata": {},
    "outputs": [],
@@ -392,7 +411,7 @@
     "    'Address', \n",
     "    'Email', \n",
     "    'Phone', \n",
-    "    'Anything else we should know? ',\n",
+    "    # 'Anything else we should know? ',\n",
     "    'PLEASE LIST ANY ALLERGIES/DIETARY RESTRICTIONS - Just type \"n/a\" if none.',\n",
     "    # 'Indicate any dietary restrictions (Peanut allergy, low sodium, vegetarian only, etc.)',\n",
     "]\n",
@@ -400,7 +419,7 @@
     "    # 'FROZEN PROTEINS - Please select only items you need; every attempt will be made to fill at least 2-3 items per family', \n",
     "    'FROZEN ITEMS',\n",
     "    'REFRIGERATED ITEMS', \n",
-    "    'Special Requests/Notes for Fresh and Frozen Items:',\n",
+    "    'Notes for Fresh and Frozen Items Only. Please use Special Notes section at beginning of order for other requests.',\n",
     "]\n",
     "summary = allorders[headerFields + refrigFields]\n",
     "allorders = allorders.drop(columns = refrigFields)"
@@ -408,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "bd847c7d-13e8-4576-b721-a2eec3bb98f0",
    "metadata": {},
    "outputs": [],
@@ -477,6 +496,10 @@
     "    <dt>Multiple Orders received from</dt>\n",
     "    <dd>{{duper}}</dd>\n",
     "{% endfor %}\n",
+    "{% for shopper in ineligible %}\n",
+    "    <dt>Order form from ineligible shopper. Probably need a valid Shopper Information Form.</dt>\n",
+    "    <dd>{{shopper}}</dd>\n",
+    "{% endfor %}\n",
     "</dl>\n",
     "''')\n",
     "\n",
@@ -491,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "291fee9b-8b63-4ec4-9372-1785b59989b7",
    "metadata": {},
    "outputs": [],
@@ -517,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "d923049b-0705-490f-bb98-81d6a5f1aa32",
    "metadata": {},
    "outputs": [],
@@ -543,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "260f18f3-1c02-4f63-afb1-f003c08837ff",
    "metadata": {},
    "outputs": [],
@@ -567,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "57b077d3-83e2-4a02-bd98-a39af7e0410e",
    "metadata": {},
    "outputs": [],
@@ -585,6 +608,7 @@
     "                            'input_file': 'from API',\n",
     "                            'output_file': order_pdf_file, \n",
     "                            'dupers': duporderers,\n",
+    "                            'ineligible': ineligible_shoppers,\n",
     "                            'starttime': starttime,\n",
     "                            'modemsg': modes[runmode],\n",
     "                            'runtime': current_run.strftime(\"%Y-%m-%d %H:%M:%S\"),\n",
@@ -606,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "f12c546a-a6dd-41e3-bf69-1352c03f66e4",
    "metadata": {},
    "outputs": [],
@@ -673,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "954c262b-a785-4dea-aca5-de04a2a09732",
    "metadata": {},
    "outputs": [],
@@ -701,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "d91f6e5a-941c-4156-a2d1-6a8919c15cce",
    "metadata": {},
    "outputs": [],
@@ -713,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "27b866db-c012-4186-b8ab-c2e722c26ac3",
    "metadata": {},
    "outputs": [],
@@ -752,7 +776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "6a4a3751-7631-4447-82f9-34f39f7d3ce7",
    "metadata": {},
    "outputs": [

--- a/PrintOrders.py
+++ b/PrintOrders.py
@@ -251,8 +251,16 @@ print('{count} shoppers to check in.'.format(count = len(shopper_ids)))
 events = breeze_api.list_events(start=title_date, end=title_date)
 shoppingevent = [e for e in events if e['name'] == 'Food Pantry'][0]
 
+eligible_ids = [e['id'] for e in breeze_api.list_eligible_people(instance_id=shoppingevent['id'])]
+ineligible_shoppers = []
+
 for id in shopper_ids:
-    check = breeze_api.event_check_in(person_id=id, instance_id=shoppingevent['id'])
+    if id in eligible_ids:
+        check = breeze_api.event_check_in(person_id=id, instance_id=shoppingevent['id'])
+    else:
+        print('Shopper ', id, ' is not eligible to check in.')
+        person = breeze_api.get_person_details(person_id = id)
+        ineligible_shoppers.append('{fname} {lname} ({id})'.format(id = id, fname = person['first_name'], lname = person['last_name']))
 
 attendance = len(breeze_api.list_attendance(instance_id=shoppingevent['id']))
 print('{count} shoppers checked in.'.format(count = attendance))
@@ -297,6 +305,12 @@ if len(duporderers) > 0:
 # In[12]:
 
 
+# allorders.columns
+
+
+# In[13]:
+
+
 # Collect the summary for only refrigerated items. ("page 1")
 # Include only the following fields in the Summary.
 
@@ -307,7 +321,7 @@ headerFields = [
     'Address', 
     'Email', 
     'Phone', 
-    'Anything else we should know? ',
+    # 'Anything else we should know? ',
     'PLEASE LIST ANY ALLERGIES/DIETARY RESTRICTIONS - Just type "n/a" if none.',
     # 'Indicate any dietary restrictions (Peanut allergy, low sodium, vegetarian only, etc.)',
 ]
@@ -315,13 +329,13 @@ refrigFields = [
     # 'FROZEN PROTEINS - Please select only items you need; every attempt will be made to fill at least 2-3 items per family', 
     'FROZEN ITEMS',
     'REFRIGERATED ITEMS', 
-    'Special Requests/Notes for Fresh and Frozen Items:',
+    'Notes for Fresh and Frozen Items Only. Please use Special Notes section at beginning of order for other requests.',
 ]
 summary = allorders[headerFields + refrigFields]
 allorders = allorders.drop(columns = refrigFields)
 
 
-# In[13]:
+# In[14]:
 
 
 # Define HTML templates using Jinja2 for printing the data.
@@ -388,6 +402,10 @@ coversheet = Template('''
     <dt>Multiple Orders received from</dt>
     <dd>{{duper}}</dd>
 {% endfor %}
+{% for shopper in ineligible %}
+    <dt>Order form from ineligible shopper. Probably need a valid Shopper Information Form.</dt>
+    <dd>{{shopper}}</dd>
+{% endfor %}
 </dl>
 ''')
 
@@ -400,7 +418,7 @@ rowhtml = Template('<tr><td class="category">{{category}}</td><td>{{items}}</td>
 
 
 
-# In[14]:
+# In[15]:
 
 
 # Format the order forms as html.
@@ -422,7 +440,7 @@ def formatshoppers(date, data):
     return output
 
 
-# In[15]:
+# In[16]:
 
 
 # Templates for the Bulk item picking pages
@@ -444,7 +462,7 @@ bulkcategory = Template('''
 ''')
 
 
-# In[16]:
+# In[17]:
 
 
 # Print out totals or order quantities for refrigerated and frozen items.
@@ -464,7 +482,7 @@ def formatbulkitems(summary):
     return output
 
 
-# In[17]:
+# In[18]:
 
 
 # Build the report using Jinja2.
@@ -480,6 +498,7 @@ output = coversheet.render({'received': ordercount,
                             'input_file': 'from API',
                             'output_file': order_pdf_file, 
                             'dupers': duporderers,
+                            'ineligible': ineligible_shoppers,
                             'starttime': starttime,
                             'modemsg': modes[runmode],
                             'runtime': current_run.strftime("%Y-%m-%d %H:%M:%S"),
@@ -499,7 +518,7 @@ output += formatbulkitems(summary)
 orders_html = orders.render({'body': output})
 
 
-# In[18]:
+# In[19]:
 
 
 # Define HTML templates using Jinja2 for printing labels
@@ -562,7 +581,7 @@ shopperlabel = Template('''
 
 
 
-# In[19]:
+# In[20]:
 
 
 # Create labels to be attached to the bags for the orders.
@@ -586,7 +605,7 @@ for _, row in allorders.iterrows():
 labels_html = labels.render({'body': output})
 
 
-# In[20]:
+# In[21]:
 
 
 # Optional: Display the report here.
@@ -594,7 +613,7 @@ labels_html = labels.render({'body': output})
 # IPython.display.HTML(orders_html)
 
 
-# In[21]:
+# In[22]:
 
 
 # Use Rapid API yakpdf - HTML to PDF to format the html output as pdf for printing.
@@ -629,7 +648,7 @@ def to_pdf(source_html):
     return response.content
 
 
-# In[22]:
+# In[23]:
 
 
 # Write out the files to print.

--- a/PrintOrders.py
+++ b/PrintOrders.py
@@ -305,12 +305,6 @@ if len(duporderers) > 0:
 # In[12]:
 
 
-# allorders.columns
-
-
-# In[13]:
-
-
 # Collect the summary for only refrigerated items. ("page 1")
 # Include only the following fields in the Summary.
 
@@ -335,7 +329,7 @@ summary = allorders[headerFields + refrigFields]
 allorders = allorders.drop(columns = refrigFields)
 
 
-# In[14]:
+# In[13]:
 
 
 # Define HTML templates using Jinja2 for printing the data.
@@ -418,7 +412,7 @@ rowhtml = Template('<tr><td class="category">{{category}}</td><td>{{items}}</td>
 
 
 
-# In[15]:
+# In[14]:
 
 
 # Format the order forms as html.
@@ -440,7 +434,7 @@ def formatshoppers(date, data):
     return output
 
 
-# In[16]:
+# In[15]:
 
 
 # Templates for the Bulk item picking pages
@@ -462,7 +456,7 @@ bulkcategory = Template('''
 ''')
 
 
-# In[17]:
+# In[16]:
 
 
 # Print out totals or order quantities for refrigerated and frozen items.
@@ -482,7 +476,7 @@ def formatbulkitems(summary):
     return output
 
 
-# In[18]:
+# In[17]:
 
 
 # Build the report using Jinja2.
@@ -518,7 +512,7 @@ output += formatbulkitems(summary)
 orders_html = orders.render({'body': output})
 
 
-# In[19]:
+# In[18]:
 
 
 # Define HTML templates using Jinja2 for printing labels
@@ -581,7 +575,7 @@ shopperlabel = Template('''
 
 
 
-# In[20]:
+# In[19]:
 
 
 # Create labels to be attached to the bags for the orders.
@@ -605,7 +599,7 @@ for _, row in allorders.iterrows():
 labels_html = labels.render({'body': output})
 
 
-# In[21]:
+# In[20]:
 
 
 # Optional: Display the report here.
@@ -613,7 +607,7 @@ labels_html = labels.render({'body': output})
 # IPython.display.HTML(orders_html)
 
 
-# In[22]:
+# In[21]:
 
 
 # Use Rapid API yakpdf - HTML to PDF to format the html output as pdf for printing.
@@ -648,7 +642,7 @@ def to_pdf(source_html):
     return response.content
 
 
-# In[23]:
+# In[22]:
 
 
 # Write out the files to print.


### PR DESCRIPTION
Breeze has eligibility rules for check-ins. We use these to ensure that people who check in have filled out the Shopper Information form (https://newmarketchurch.breezechms.com/form/21656091).

Checking in with the API does not perform this eligibility check, so we have to do that via an additional API call.

Tested in production with an ineligible shopper on 2024-09-12.